### PR TITLE
refactor(blog): 統一文章 tag 樣式為共用 TagList 元件

### DIFF
--- a/src/components/Article.astro
+++ b/src/components/Article.astro
@@ -1,7 +1,7 @@
 ---
 import dayjs from 'dayjs';
 import { twMerge } from 'tailwind-merge'
-import { Icon } from 'astro-icon/components';
+import TagList from '@/components/TagList.astro';
 
 const {
   feature_image_url,
@@ -56,22 +56,7 @@ const publish_time = dayjs(date).format('YYYY 年 MM 月 DD 日');
         )
       }
     </div>
-    {tags && tags.length > 0 && (
-      <div class="flex items-center gap-0.5 mt-3 flex-wrap">
-        <Icon class="text-secondary/70 mr-1" name="bx:label" title="tags" />
-        {tags.map((tag, index) => (
-          <>
-            <a
-              href={currentLocale === 'en' ? `/en/tags/${tag}` : `/tags/${tag}`}
-              class="py-0.5 rounded text-xs font-medium text-base-content transition-colors duration-200 link link-hover"
-            >
-              {tag}
-            </a>
-            {index < tags.length - 1 && <span>・</span>}
-          </>
-        ))}
-      </div>
-    )}
+    <TagList tags={tags} lang={currentLocale} />
   </header>
 
   {feature_image_url && (

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -3,6 +3,7 @@ import { Icon } from 'astro-icon/components';
 import dayjs from 'dayjs';
 import Link from '@/components/Link.astro';
 import ReadMoreButton from '../components/ReadMoreButton.astro';
+import TagList from '@/components/TagList.astro';
 
 const { lang, postList } = Astro.props;
 const root_path = lang == 'en' ? '/en' : '';
@@ -62,23 +63,7 @@ const root_path = lang == 'en' ? '/en' : '';
               </Link>
 
               <div class="flex justify-end items-center gap-x-1">
-                {(post.tags && post.tags.length > 0) && (
-                  <div class="flex items-center gap-0.5">
-                    <Icon class="text-secondary/70 mr-1" name="bx:hash" title="tags" />
-
-                    {post.tags.map((tag, index) => (
-                      <>
-                        <a
-                          href={`${root_path}/tags/${tag}`}
-                          class="py-0.5 rounded text-xs font-medium  transition-colors duration-200 link link-hover"
-                        >
-                          {tag}
-                        </a>
-                        {index < post.tags.length - 1 && <span>・</span>}
-                      </>
-                    ))}
-                  </div>
-                )}
+                <TagList tags={post.tags} lang={lang} />
               </div>
             </header>
           </article>

--- a/src/components/TagList.astro
+++ b/src/components/TagList.astro
@@ -1,0 +1,25 @@
+---
+import { Icon } from 'astro-icon/components';
+
+const { tags, lang, currentTag } = Astro.props;
+const root_path = lang === 'en' ? '/en' : '';
+---
+
+{tags && tags.length > 0 && (
+  <div class="flex items-center gap-0.5 mt-3 flex-wrap">
+    <Icon class="text-secondary/70 mr-1" name="bx:label" title="tags" />
+    {tags.map((tag, index) => (
+      <>
+        <a
+          href={`${root_path}/tags/${tag}`}
+          class={`py-0.5 rounded text-xs font-medium transition-colors duration-200 link link-hover ${
+            tag === currentTag ? 'font-bold text-primary' : ''
+          }`}
+        >
+          {tag}
+        </a>
+        {index < tags.length - 1 && <span>・</span>}
+      </>
+    ))}
+  </div>
+)}

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Layout from '@/layouts/page.astro';
+import TagList from '@/components/TagList.astro';
 
 export const getStaticPaths = async () => {
   const posts = await getCollection('posts-tw');
@@ -112,18 +113,7 @@ const pageDescription = `查看所有「${category}」分類的文章，共 ${po
               )}
 
               <!-- Post tags -->
-              {post.data.tags && post.data.tags.length > 0 && (
-                <div class="flex flex-wrap gap-2 mt-3">
-                  {post.data.tags.map(tag => (
-                    <a
-                      href={`/tags/${tag}`}
-                      class="px-2 py-1 rounded text-xs font-medium bg-base-300 text-base-content hover:bg-base-400 transition-colors duration-200"
-                    >
-                      {tag}
-                    </a>
-                  ))}
-                </div>
-              )}
+              <TagList tags={post.data.tags} lang="tw" />
             </div>
           </article>
         );

--- a/src/pages/en/categories/[category].astro
+++ b/src/pages/en/categories/[category].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Layout from '@/layouts/page.astro';
+import TagList from '@/components/TagList.astro';
 
 export const getStaticPaths = async () => {
   const posts = await getCollection('posts-en');
@@ -112,18 +113,7 @@ const pageDescription = `Browse all articles in "${category}" category, ${posts.
               )}
 
               <!-- Post tags -->
-              {post.data.tags && post.data.tags.length > 0 && (
-                <div class="flex flex-wrap gap-2 mt-3">
-                  {post.data.tags.map(tag => (
-                    <a
-                      href={`/en/tags/${tag}`}
-                      class="px-2 py-1 rounded text-xs font-medium bg-base-300 text-base-content hover:bg-base-400 transition-colors duration-200"
-                    >
-                      {tag}
-                    </a>
-                  ))}
-                </div>
-              )}
+              <TagList tags={post.data.tags} lang="en" />
             </div>
           </article>
         );

--- a/src/pages/en/tags/[tag].astro
+++ b/src/pages/en/tags/[tag].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Layout from '@/layouts/page.astro';
+import TagList from '@/components/TagList.astro';
 
 export const getStaticPaths = async () => {
   const posts = await getCollection('posts-en');
@@ -113,22 +114,7 @@ const pageDescription = `View all articles tagged with "${tag}", ${posts.length}
               )}
 
               <!-- Post tags -->
-              {post.data.tags && post.data.tags.length > 0 && (
-                <div class="flex flex-wrap gap-2 mt-3">
-                  {post.data.tags.map(postTag => (
-                    <a
-                      href={`/en/tags/${postTag}`}
-                      class={`px-2 py-1 rounded text-xs font-medium transition-colors duration-200 ${
-                        postTag === tag
-                          ? 'bg-primary text-primary-content'
-                          : 'bg-base-300 text-base-content hover:bg-base-400'
-                      }`}
-                    >
-                      {postTag}
-                    </a>
-                  ))}
-                </div>
-              )}
+              <TagList tags={post.data.tags} lang="en" currentTag={tag} />
             </div>
           </article>
         );

--- a/src/pages/tags.astro
+++ b/src/pages/tags.astro
@@ -88,7 +88,7 @@ const pageDescription = '按分類瀏覽所有標籤，快速找到感興趣的�
                 class="inline-flex items-center px-3 py-2 rounded-lg bg-base-300 text-base-content hover:text-blue-900 transition-colors duration-200 text-sm font-medium"
               >
                 {tag.name}
-                <span class="ml-2 px-2 py-1 bg-base-400 rounded-full text-xs">
+                <span class="ml-2 px-2 py-1 bg-base-100 rounded-full text-xs">
                   {tag.count}
                 </span>
               </a>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import Layout from '@/layouts/page.astro';
+import TagList from '@/components/TagList.astro';
 
 export const getStaticPaths = async () => {
   const posts = await getCollection('posts-tw');
@@ -113,22 +114,7 @@ const pageDescription = `查看所有標記為「${tag}」的文章，共 ${post
               )}
 
               <!-- 文章標籤 -->
-              {post.data.tags && post.data.tags.length > 0 && (
-                <div class="flex flex-wrap gap-2 mt-3">
-                  {post.data.tags.map(postTag => (
-                    <a
-                      href={`/tags/${postTag}`}
-                      class={`px-2 py-1 rounded text-xs font-medium transition-colors duration-200 ${
-                        postTag === tag
-                          ? 'bg-primary text-primary-content'
-                          : 'bg-base-300 text-base-content hover:bg-base-400'
-                      }`}
-                    >
-                      {postTag}
-                    </a>
-                  ))}
-                </div>
-              )}
+              <TagList tags={post.data.tags} lang="tw" currentTag={tag} />
             </div>
           </article>
         );


### PR DESCRIPTION
article list、文章詳情頁、tag/category 封存頁原本用三組不同樣式
渲染 tag（裸連結、膠囊、icon 也不同），且封存頁 hover 引用不存在
的 bg-base-400。抽出 TagList.astro 共用元件集中管理樣式，統一改為
bx:label icon + 裸連結 + ・ 分隔，封存頁當前 tag 以 font-bold
text-primary 高亮。順手修正 tags.astro 計數 badge 的 bg-base-400。